### PR TITLE
Add support.class to “Types” highlight rule

### DIFF
--- a/themes/darcula.json
+++ b/themes/darcula.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "Types, Class Types",
-      "scope": "entity.name.type,meta.return.type,meta.type.annotation,meta.type.parameters,support.type.primitive,support.type.class",
+      "scope": "entity.name.type,meta.return.type,meta.type.annotation,meta.type.parameters,support.type.primitive,support.class",
       "settings": {
         "foreground": "#7A9EC2"
       }

--- a/themes/darcula.json
+++ b/themes/darcula.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "Types, Class Types",
-      "scope": "entity.name.type,meta.return.type,meta.type.annotation,meta.type.parameters,support.type.primitive",
+      "scope": "entity.name.type,meta.return.type,meta.type.annotation,meta.type.parameters,support.type.primitive,support.type.class",
       "settings": {
         "foreground": "#7A9EC2"
       }


### PR DESCRIPTION
This fixes highlighting for Dart.

Before:

![image](https://user-images.githubusercontent.com/16232127/87703753-9d3b7800-c79b-11ea-8155-e0f2d07e9b7d.png)

After:

![image](https://user-images.githubusercontent.com/16232127/87703788-a9bfd080-c79b-11ea-96c4-21d9b118b7cb.png)

