### PR TITLE
Add diff colors

### DIFF
--- a/themes/darcula.json
+++ b/themes/darcula.json
@@ -476,6 +476,27 @@
       "settings": {
         "foreground": "#FFC66D"
       }
+    },
+    {
+      "name": "diff: inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#447152"
+      }
+    },
+    {
+      "name": "diff: deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#656e76"
+      }
+    },
+    {
+      "name": "diff: changed",
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#43698d"
+      }
     }
   ]
 }


### PR DESCRIPTION
I was kinda sad that the theme doesn't include the scheming for diffs... I chose the highlighting colors, since I've found only one token for it in the theme configuration

based on CLion there were 2 sets of colors, lighter and darker... Chose lighter since it is easier to read in the patch files.

Signed-off-by: Matej Focko <me@mfocko.xyz>