### PR TITLE
Line number / gutter background

### DIFF
--- a/themes/darcula.json
+++ b/themes/darcula.json
@@ -4,7 +4,7 @@
     "editor.background": "#242424",
     "editor.foreground": "#cccccc",
     "editor.selectionBackground": "#204182cc",
-    "editor.lineHighlightBackground": "#ffffff0b",
+    "editor.lineHighlightBackground": "#ffffff00",
     "editor.activeLineNumber.foreground": "#cccccc",
     "editorGutter.background": "#ffffff0b",
     "titleBar.activeBackground": "#ffffff1a",


### PR DESCRIPTION
I see no reason why the gutter (line numbers)  BG should be highlighted. This make the text too close to the margin, and there's not reason to emphasize it. Also mentioned here: https://stackoverflow.com/questions/65659354/what-is-the-name-of-configuration-to-change-the-background-of-line-number-vscode